### PR TITLE
Add modern build setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+package-lock.json
+bijarniadream.css
+bijarniadream.css.map
+bijarniadream.min.css
+bijarniadream.min.css.map

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # bijarniadream-css
+
 A Part of BijarniaDream
+
+## Building from source
+
+Install dependencies with `npm install` and run `npm run build` to compile the
+SCSS into optimized CSS. The `build` script uses the modern `sass` compiler and
+PostCSS with `autoprefixer` and `cssnano` to generate minified CSS with vendor
+prefixes.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bijarniadream-css",
+  "version": "1.4.0",
+  "description": "CSS utility library for responsive design",
+  "scripts": {
+    "build": "npm run css && npm run minify",
+    "css": "sass bijarniadream.scss bijarniadream.css",
+    "minify": "postcss bijarniadream.css -o bijarniadream.min.css"
+  },
+  "devDependencies": {
+    "sass": "^1.70.0",
+    "postcss": "^8.4.31",
+    "postcss-cli": "^10.1.0",
+    "autoprefixer": "^10.4.14",
+    "cssnano": "^6.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    require('autoprefixer'),
+    require('cssnano')({ preset: 'default' })
+  ]
+};


### PR DESCRIPTION
## Summary
- add build tools using `sass` and `postcss`
- document build instructions
- ignore generated files and node modules

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684278a8ddf08328a8de151ecc202ebf